### PR TITLE
LandmarkWriter class and Swapping Util

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -63,6 +63,13 @@ target_link_libraries(rt_plot_landmarks
     Boost::program_options
 )
 
+add_executable(rt_swap_landmarks src/SwapLandmarks.cpp)
+target_link_libraries(rt_swap_landmarks
+    rt::rtlib
+    Boost::filesystem
+    Boost::program_options
+)
+
 find_package(Eigen3)
 add_library(eigen3 INTERFACE IMPORTED)
 set_target_properties(eigen3 PROPERTIES

--- a/apps/src/SwapLandmarks.cpp
+++ b/apps/src/SwapLandmarks.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+#include "rt/LandmarkReader.hpp"
+#include "rt/io/LandmarkWriter.hpp"
+
+using namespace rt;
+
+namespace po = boost::program_options;
+namespace fs = boost::filesystem;
+
+int main(int argc, char* argv[])
+{
+    ///// Parse the command line options /////
+    // clang-format off
+    po::options_description required("General Options");
+    required.add_options()
+        ("help,h", "Show this message")
+        ("input-landmarks,i", po::value<std::string>()->required(),
+         "Input landmarks file")
+        ("output-landmarks,o", po::value<std::string>()->required(),
+         "Output landmarks file");
+
+    po::options_description all("Usage");
+    all.add(required);
+    // clang-format on
+
+    // Parse the cmd line
+    po::variables_map parsed;
+    po::store(po::command_line_parser(argc, argv).options(all).run(), parsed);
+
+    // Show the help message
+    if (parsed.count("help") || argc < 4) {
+        std::cerr << all << std::endl;
+        return EXIT_SUCCESS;
+    }
+
+    // Warn of missing options
+    try {
+        po::notify(parsed);
+    } catch (po::error& e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    fs::path inputPath = parsed["input-landmarks"].as<std::string>();
+    fs::path outputPath = parsed["output-landmarks"].as<std::string>();
+
+    ///// Read input file /////
+    LandmarkReader reader;
+    reader.setLandmarksPath(inputPath);
+    reader.readRaw();
+
+    // Swap landmarks
+    auto movingLandmarks = reader.getFixedLandmarks();
+    auto fixedLandmarks = reader.getMovingLandmarks();
+
+    // Write landmarks
+    LandmarkWriter writer;
+    writer.setPath(outputPath);
+    writer.setFixedLandmarks(fixedLandmarks);
+    writer.setMovingLandmarks(movingLandmarks);
+    writer.write();
+}

--- a/rtlib/CMakeLists.txt
+++ b/rtlib/CMakeLists.txt
@@ -7,6 +7,7 @@ set(io_srcs
     src/OBJWriter.cpp
     src/ReadRawTIFF.cpp
     src/LandmarkReader.cpp
+    src/LandmarkWriter.cpp
 )
 
 set(type_srcs

--- a/rtlib/include/rt/LandmarkReader.hpp
+++ b/rtlib/include/rt/LandmarkReader.hpp
@@ -18,8 +18,10 @@ class LandmarkReader
 {
 public:
     /** @brief Default constructor */
-    LandmarkReader(const boost::filesystem::path& landmarksPath)
-        : landmarksPath_(landmarksPath)
+    LandmarkReader() = default;
+
+    LandmarkReader(boost::filesystem::path landmarksPath)
+        : landmarksPath_(std::move(landmarksPath))
     {
     }
 
@@ -37,6 +39,8 @@ public:
 
     /** @brief Read the Landmarks file */
     void read();
+
+    void readRaw();
 
     /** @brief Get the parsed fixed landmarks */
     rt::LandmarkContainer getFixedLandmarks() { return fixedLandmarks_; }

--- a/rtlib/include/rt/io/LandmarkWriter.hpp
+++ b/rtlib/include/rt/io/LandmarkWriter.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+
+#include "rt/LandmarkRegistrationBase.hpp"
+
+namespace rt
+{
+
+class LandmarkWriter
+{
+public:
+    LandmarkWriter() = default;
+    void setPath(boost::filesystem::path p) { outputPath_ = p; }
+    void setFixedLandmarks(LandmarkContainer f) { fixedLandmarks_ = f; }
+    void setMovingLandmarks(LandmarkContainer m) { movingLandmarks_ = m; }
+
+    void write();
+
+private:
+    boost::filesystem::path outputPath_;
+
+    LandmarkContainer fixedLandmarks_;
+    LandmarkContainer movingLandmarks_;
+};
+}  // namespace rt

--- a/rtlib/src/LandmarkReader.cpp
+++ b/rtlib/src/LandmarkReader.cpp
@@ -70,3 +70,44 @@ void LandmarkReader::read()
     }
     ifs.close();
 }
+
+void LandmarkReader::readRaw()
+{
+    // Check that input is set
+    if (!fs::exists(landmarksPath_)) {
+        throw std::runtime_error("Invalid input. Unable to read.");
+    }
+
+    // Reset landmark containers
+    fixedLandmarks_.clear();
+    movingLandmarks_.clear();
+
+    // Read the landmarks file
+    rt::Landmark fixedPoint, movingPoint;
+    itk::ContinuousIndex<double, 2> fixedIndex, movingIndex;
+
+    std::ifstream ifs(landmarksPath_.string());
+    std::string line;
+    std::vector<std::string> strs;
+    while (std::getline(ifs, line)) {
+        // Parse the line
+        boost::trim(line);
+        boost::split(strs, line, boost::is_any_of(" "));
+        std::for_each(std::begin(strs), std::end(strs), [](std::string& t) {
+            boost::trim(t);
+        });
+
+        if (strs.size() != 4) {
+            continue;
+        }
+
+        fixedIndex[0] = std::stod(strs[0]);
+        fixedIndex[1] = std::stod(strs[1]);
+        movingIndex[0] = std::stod(strs[2]);
+        movingIndex[1] = std::stod(strs[3]);
+
+        fixedLandmarks_.push_back(fixedIndex);
+        movingLandmarks_.push_back(movingIndex);
+    }
+    ifs.close();
+}

--- a/rtlib/src/LandmarkWriter.cpp
+++ b/rtlib/src/LandmarkWriter.cpp
@@ -1,0 +1,38 @@
+#include "rt/io/LandmarkWriter.hpp"
+
+#include <iostream>
+
+using namespace rt;
+
+void LandmarkWriter::write()
+{
+    // Check parameters
+    if (outputPath_.empty()) {
+        throw std::runtime_error("Empty file path");
+    }
+
+    if (fixedLandmarks_.empty() || movingLandmarks_.empty()) {
+        throw std::runtime_error("Empty landmark containers");
+    }
+
+    if (fixedLandmarks_.size() != movingLandmarks_.size()) {
+        throw std::runtime_error("Landmark containers of different size");
+    }
+
+    // Open file
+    std::ofstream file(outputPath_.string());
+    if (!file.is_open()) {
+        throw std::runtime_error("Unable to open output file");
+    }
+
+    // Write the landmarks
+    for (size_t i = 0; i < fixedLandmarks_.size(); i++) {
+        file << fixedLandmarks_.at(i)[0] << " ";
+        file << fixedLandmarks_.at(i)[1] << " ";
+        file << movingLandmarks_.at(i)[0] << " ";
+        file << movingLandmarks_.at(i)[1] << "\n";
+    }
+
+    // Close file
+    file.close();
+}


### PR DESCRIPTION
(rtlib) LandmarkWriter class.
(apps) Util to swap fixed and moving landmarks