### PR TITLE
Add support for OCV4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-# registration-toolkit
-# Written by: Stephen Parson, Zack Anderson, and the VC Project Team
-
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
 project("registration-toolkit" VERSION 0.1.0)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)

--- a/apps/src/ReorderTexture.cpp
+++ b/apps/src/ReorderTexture.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[])
     // We don't support RGBA textures
     auto channels = texture.channels();
     if (channels == 4) {
-        cv::cvtColor(texture, texture, CV_BGRA2BGR);
+        cv::cvtColor(texture, texture, cv::COLOR_BGRA2BGR);
     } else if (channels != 1 && channels != 3) {
         std::cerr << "Texture has unsupported channels: " << channels << "\n";
     }

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -10,7 +10,10 @@ find_package(Sanitizers)
 find_package(Boost REQUIRED COMPONENTS filesystem program_options)
 
 ### OpenCV ###
-find_package(OpenCV 3 REQUIRED)
+find_package(OpenCV 3 QUIET)
+if(NOT OpenCV_FOUND)
+    find_package(OpenCV 4 QUIET REQUIRED)
+endif()
 
 ### ITK ###
 find_package(ITK REQUIRED)

--- a/rtlib/include/rt/ReorderUnorganizedTexture.hpp
+++ b/rtlib/include/rt/ReorderUnorganizedTexture.hpp
@@ -68,7 +68,7 @@ public:
      */
     void setSampleRate(double s) { sampleRate_ = s; }
     /** @brief Set whether to use the first mesh intersection point */
-    void setUseFirstIntersection(bool b) { useFirstInterection_ = b; };
+    void setUseFirstIntersection(bool b) { useFirstInterection_ = b; }
     /**@}*/
 
     /**@{*/


### PR DESCRIPTION
Fixes CMake configs and includes to support OpenCV4. This should also be backwards compatible with OpenCV3.