### PR TITLE
Improve stability of LandmarkDetector class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 LandmarkGenerator/bin/
 LandmarkGenerator/runnable.jar
-*build/
-*cmake-build-*/
-*.png
+**build/
+**installed/
+**cmake-build-*/
+**.png
 !utils/crosshair.png
-*.jpg
-*.mhd
-*.raw
+**.jpg
+**.mhd
+**.raw
 
 *.iconset/
 *bin/

--- a/rtlib/CMakeLists.txt
+++ b/rtlib/CMakeLists.txt
@@ -41,10 +41,10 @@ target_link_libraries(${target}
         vtkCommonCore
         vtkCommonDataModel
     PRIVATE
-        opencv_calib3d
         opencv_features2d
         opencv_imgcodecs
         opencv_imgproc
+        opencv_stitching
         ITKOptimizers
         vtkCommonTransforms
         vtkFiltersGeneral

--- a/rtlib/include/rt/LandmarkDetector.hpp
+++ b/rtlib/include/rt/LandmarkDetector.hpp
@@ -72,6 +72,6 @@ private:
     /** Matched pairs */
     std::vector<LandmarkPair> output_;
     /** Nearest-neighbor matching ratio */
-    float nnMatchRatio_{0.8f};
+    float nnMatchRatio_{0.2f};
 };
 }

--- a/rtlib/src/LandmarkDetector.cpp
+++ b/rtlib/src/LandmarkDetector.cpp
@@ -19,20 +19,14 @@ std::vector<rt::LandmarkPair> LandmarkDetector::compute()
     // Clear the output vector
     output_.clear();
 
-    // UMats for OpenCL support (if available)
-    cv::UMat fixedImage;
-    cv::UMat movingImage;
-    fixedImg_.copyTo(fixedImage);
-    movingImg_.copyTo(movingImage);
-
     // Detect key points and compute their descriptors
     auto featureDetector = cv::AKAZE::create();
     std::vector<cv::detail::ImageFeatures> features(2);
-    std::vector<cv::UMat> images{fixedImage, movingImage};
+    std::vector<cv::Mat> images{fixedImg_, movingImg_};
     cv::detail::computeImageFeatures(featureDetector, images, features);
 
     // Match keypoints
-    cv::detail::BestOf2NearestMatcher matcher(true, nnMatchRatio_);
+    cv::detail::BestOf2NearestMatcher matcher(false, nnMatchRatio_);
     std::vector<cv::detail::MatchesInfo> matches;
     matcher(features, matches);
     matcher.collectGarbage();


### PR DESCRIPTION
This pull request updates `rt::LandmarkDetector` to use the classes provided by `opencv_stitching` for feature computation and filtering. Previously, we had manually implemented a best-of-two matcher + inlier filtering. Now we piggyback off the `cv::detail::BestOf2NearestMatcher,` which does all of that for us.