### PR TITLE
(ImageResampleNode) Fix forceAlpha being ignored

### DIFF
--- a/apps/src/Register.cpp
+++ b/apps/src/Register.cpp
@@ -220,6 +220,7 @@ auto main(int argc, char* argv[]) -> int
         resample2->fixedImage = *results["fixedImage"];
         resample2->movingImage = moving->image;
         resample2->transform = compositeTfms->result;
+	resample2->forceAlpha = parsed.count("enable-alpha") > 0;	
 
         ///// Write the output image /////
         auto writer = graph.insertNode<ImageWriteNode>();

--- a/graph/src/Transforms.cpp
+++ b/graph/src/Transforms.cpp
@@ -175,6 +175,7 @@ rtg::ImageResampleNode::ImageResampleNode() : Node{true}
     registerInputPort("fixedImage", fixedImage);
     registerInputPort("movingImage", movingImage);
     registerInputPort("transform", transform);
+    registerInputPort("forceAlpha", forceAlpha);
     registerOutputPort("resampledImage", resampledImage);
 
     compute = [=]() {
@@ -186,7 +187,7 @@ rtg::ImageResampleNode::ImageResampleNode() : Node{true}
             tmp = moving_;
         }
         std::cout << "Resampling image..." << std::endl;
-        resampled_ = ImageTransformResampler(moving_, fixed_.size(), tfm_);
+        resampled_ = ImageTransformResampler(tmp, fixed_.size(), tfm_);
     };
 }
 


### PR DESCRIPTION
Added a RegisterInputPort for forceAlpha at the Image Resample Node and ensured the tmp variable for the moving image was being used 