### PR TITLE
(rt_reorder_texture) Add depth map option

### DIFF
--- a/apps/src/ReorderTexture.cpp
+++ b/apps/src/ReorderTexture.cpp
@@ -43,6 +43,7 @@ auto main(int argc, char* argv[]) -> int
              "Path to input OBJ with unordered texture (i.e. multicharts)")
         ("output-mesh,o", po::value<std::string>()->required(),
              "Path to output OBJ with ordered texture")
+        ("depth-map", po::value<std::string>(), "Path to output depth map image")
         ("sampling-origin", po::value<std::string>()->default_value("tl"),
              "Origins: tl, tr, bl, br")
         ("sampling-mode,m", po::value<std::string>()->default_value("auto"),
@@ -143,6 +144,13 @@ auto main(int argc, char* argv[]) -> int
     writer->mesh = reader->mesh;
     writer->uvMap = reorder->uvMapOut;
     writer->image = reorder->imageOut;
+
+    // Write depth map
+    if (parsed.count("depth-map") > 0) {
+        auto imgWriter = graph.insertNode<ImageWriteNode>();
+        imgWriter->path = parsed["depth-map"].as<std::string>();
+        imgWriter->image = reorder->depthMapOut;
+    }
 
     // Compute result
     graph.update();

--- a/core/include/rt/ReorderUnorganizedTexture.hpp
+++ b/core/include/rt/ReorderUnorganizedTexture.hpp
@@ -127,6 +127,13 @@ public:
     /** @brief Get the output texture image */
     auto getTextureMat() -> cv::Mat;
 
+    /**
+     * @brief Get depth map relative to the bounding box plane
+     *
+     * Depth is a floating point image in mesh units.
+     */
+    auto getDepthMap() -> cv::Mat;
+
 private:
     /** Resample the input image into the organized texture */
     void create_texture_();
@@ -167,5 +174,7 @@ private:
     UVMap outputUV_;
     /** Output texture image */
     cv::Mat outputTexture_;
+    /** Output depth map */
+    cv::Mat outputDepthMap_;
 };
 }  // namespace rt

--- a/core/src/ReorderUnorganizedTexture.cpp
+++ b/core/src/ReorderUnorganizedTexture.cpp
@@ -174,6 +174,11 @@ auto ReorderUnorganizedTexture::getTextureMat() -> cv::Mat
     return outputTexture_;
 }
 
+auto ReorderUnorganizedTexture::getDepthMap() -> cv::Mat
+{
+    return outputDepthMap_;
+}
+
 // Compute the result
 auto ReorderUnorganizedTexture::compute() -> cv::Mat
 {
@@ -256,6 +261,7 @@ void ReorderUnorganizedTexture::create_texture_()
 
     // Setup the output image
     outputTexture_ = cv::Mat::zeros(rows, cols, CV_8UC3);
+    outputDepthMap_ = cv::Mat::zeros(rows, cols, CV_32FC1);
 
     // Normalize the length
     auto normedX = cv::normalize(xAxis_);
@@ -310,6 +316,10 @@ void ReorderUnorganizedTexture::create_texture_()
             if (not hit) {
                 continue;
             }
+
+            // Assign distance to depth map
+            outputDepthMap_.at<float>(v, u) =
+                static_cast<float>(hit->distance());
 
             // Cell info
             auto cellId = hit->primitive_index;

--- a/graph/include/rt/graph/MeshOps.hpp
+++ b/graph/include/rt/graph/MeshOps.hpp
@@ -9,9 +9,7 @@
 #include "rt/types/ITKMesh.hpp"
 #include "rt/types/UVMap.hpp"
 
-namespace rt
-{
-namespace graph
+namespace rt::graph
 {
 /**
  * @brief Reorder unorganized texture
@@ -54,6 +52,8 @@ public:
     smgl::OutputPort<cv::Mat> imageOut;
     /** @brief Output UV Map port */
     smgl::OutputPort<UVMap> uvMapOut;
+    /** @brief Output depth map port */
+    smgl::OutputPort<cv::Mat> depthMapOut;
     /**@}*/
 
 private:
@@ -71,5 +71,4 @@ private:
     void deserialize_(
         const smgl::Metadata& meta, const filesystem::path& cacheDir) override;
 };
-}  // namespace graph
 }  // namespace rt

--- a/graph/src/MeshOps.cpp
+++ b/graph/src/MeshOps.cpp
@@ -42,6 +42,7 @@ rtg::ReorderTextureNode::ReorderTextureNode()
     , useFirstIntersection{&reorder_, &ReorderUnorganizedTexture::setUseFirstIntersection}
     , imageOut{&outImg_}
     , uvMapOut{&outUV_}
+    , depthMapOut{&reorder_, &ReorderUnorganizedTexture::getDepthMap}
 {
     registerInputPort("mesh", meshIn);
     registerInputPort("imageIn", imageIn);
@@ -53,6 +54,7 @@ rtg::ReorderTextureNode::ReorderTextureNode()
     registerInputPort("useFirstIntersection", useFirstIntersection);
     registerOutputPort("imageOut", imageOut);
     registerOutputPort("uvMapOut", uvMapOut);
+    registerOutputPort("depthMapOut", depthMapOut);
 
     compute = [this]() {
         std::cout << "Reordering texture image...\n";
@@ -79,6 +81,8 @@ auto rtg::ReorderTextureNode::serialize_(
         if (not outImg_.empty()) {
             WriteImage(cacheDir / "reordered_img.tif", outImg_);
             m["image"] = "reordered_img.tif";
+            WriteImage(cacheDir / "depth_map.tif", reorder_.getDepthMap());
+            m["depth-map"] = "depth_map.tif";
         }
     }
     return m;


### PR DESCRIPTION
Add options to save the depth map implicitly generated by `ReorderUnorganizedTexture`.